### PR TITLE
Update Cypress Viewport Data (Automatic Update)

### DIFF
--- a/config/cypress.json
+++ b/config/cypress.json
@@ -13,8 +13,8 @@
         "list": "VA Top Mobile Viewports",
         "rank": 1,
         "devicesWithViewport": "iPhone XS Max, iPhone XR, iPhone 11, iPhone 11 Pro Max",
-        "percentTraffic": 7.2,
-        "percentTrafficPeriod": "December, 2020",
+        "percentTraffic": "7.54%",
+        "percentTrafficPeriod": "From: 12/01/2020, To: 12/31/2020",
         "viewportPreset": "va-top-mobile-1",
         "width": 414,
         "height": 896
@@ -23,8 +23,8 @@
         "list": "VA Top Mobile Viewports",
         "rank": 2,
         "devicesWithViewport": "iPhone X, iPhone XS, iPhone 11 Pro",
-        "percentTraffic": 4.11,
-        "percentTrafficPeriod": "December, 2020",
+        "percentTraffic": "4.32%",
+        "percentTrafficPeriod": "From: 12/01/2020, To: 12/31/2020",
         "viewportPreset": "va-top-mobile-2",
         "width": 375,
         "height": 812
@@ -32,9 +32,9 @@
       {
         "list": "VA Top Mobile Viewports",
         "rank": 3,
-        "devicesWithViewport": "iPhone 6, iPhone 6s, iPhone 7, iPhone 8",
-        "percentTraffic": 4.07,
-        "percentTrafficPeriod": "December, 2020",
+        "devicesWithViewport": "iPhone SE 2nd gen, iPhone 6, iPhone 6s, iPhone 7, iPhone 8",
+        "percentTraffic": "4.24%",
+        "percentTrafficPeriod": "From: 12/01/2020, To: 12/31/2020",
         "viewportPreset": "va-top-mobile-3",
         "width": 375,
         "height": 667
@@ -43,8 +43,8 @@
         "list": "VA Top Mobile Viewports",
         "rank": 4,
         "devicesWithViewport": "iPhone 6 Plus, iPhone 6s Plus, iPhone 7 Plus, iPhone 8 Plus",
-        "percentTraffic": 2.13,
-        "percentTrafficPeriod": "December, 2020",
+        "percentTraffic": "2.26%",
+        "percentTrafficPeriod": "From: 12/01/2020, To: 12/31/2020",
         "viewportPreset": "va-top-mobile-4",
         "width": 414,
         "height": 736
@@ -53,8 +53,8 @@
         "list": "VA Top Mobile Viewports",
         "rank": 5,
         "devicesWithViewport": "Various Samsung Galaxy, Motorola, Huawei, and other phones",
-        "percentTraffic": 1.34,
-        "percentTrafficPeriod": "December, 2020",
+        "percentTraffic": "1.39%",
+        "percentTrafficPeriod": "From: 12/01/2020, To: 12/31/2020",
         "viewportPreset": "va-top-mobile-5",
         "width": 360,
         "height": 640
@@ -64,9 +64,9 @@
       {
         "list": "VA Top Tablet Viewports",
         "rank": 1,
-        "devicesWithViewport": "iPad 1-6, iPad mini, iPad Air 1-2, iPad Pro (1st gen 9.7 inch)",
-        "percentTraffic": 1.19,
-        "percentTrafficPeriod": "December, 2020",
+        "devicesWithViewport": "iPad 1-6, iPad mini, iPad Air 1-2, iPad Pro (1st gen 9.7\")",
+        "percentTraffic": "1.28%",
+        "percentTrafficPeriod": "From: 12/01/2020, To: 12/31/2020",
         "viewportPreset": "va-top-tablet-1",
         "width": 768,
         "height": 1024
@@ -75,8 +75,8 @@
         "list": "VA Top Tablet Viewports",
         "rank": 2,
         "devicesWithViewport": "Microsoft Windows RT Tablet",
-        "percentTraffic": 0.41,
-        "percentTrafficPeriod": "December, 2020",
+        "percentTraffic": "0.43%",
+        "percentTrafficPeriod": "From: 12/01/2020, To: 12/31/2020",
         "viewportPreset": "va-top-tablet-2",
         "width": 1920,
         "height": 1080
@@ -85,8 +85,8 @@
         "list": "VA Top Tablet Viewports",
         "rank": 3,
         "devicesWithViewport": "Microsoft Windows RT Tablet",
-        "percentTraffic": 0.22,
-        "percentTrafficPeriod": "December, 2020",
+        "percentTraffic": "0.24%",
+        "percentTrafficPeriod": "From: 12/01/2020, To: 12/31/2020",
         "viewportPreset": "va-top-tablet-3",
         "width": 1280,
         "height": 720
@@ -95,8 +95,8 @@
         "list": "VA Top Tablet Viewports",
         "rank": 4,
         "devicesWithViewport": "Amazon KSFUWI Fire HD 10 (2017), Amazon KFMAWI Fire HD 10 (2019), Samsung SM-T580 Galaxy Tab A 10.1, Samsung SM-T510 Galaxy Tab A 10.1 (2019), Samsung SM-T560NU Galaxy Tab E",
-        "percentTraffic": 0.17,
-        "percentTrafficPeriod": "December, 2020",
+        "percentTraffic": "0.18%",
+        "percentTrafficPeriod": "From: 12/01/2020, To: 12/31/2020",
         "viewportPreset": "va-top-tablet-4",
         "width": 800,
         "height": 1280
@@ -104,21 +104,21 @@
       {
         "list": "VA Top Tablet Viewports",
         "rank": 5,
-        "devicesWithViewport": "Amazon KFGIWI Kindle Fire HD 8 2016, Amazon KFDOWI Kindle Fire HD 8 (2017), Amazon KFKAWI Fire HD 8 (2018), Amazon KFKAWI Fire HD 8 (2018)",
-        "percentTraffic": 0.14,
-        "percentTrafficPeriod": "December, 2020",
+        "devicesWithViewport": "This viewport is missing from the devices lookup table. Please contact the Testing Tools Team to have it added.",
+        "percentTraffic": "0.15%",
+        "percentTrafficPeriod": "From: 12/01/2020, To: 12/31/2020",
         "viewportPreset": "va-top-tablet-5",
-        "width": 601,
-        "height": 962
+        "width": 1280,
+        "height": 800
       }
     ],
     "vaTopDesktopViewports": [
       {
         "list": "VA Top Desktop Viewports",
         "rank": 1,
-        "devicesWithViewport": "Unknown",
-        "percentTraffic": 27.61,
-        "percentTrafficPeriod": "December, 2020",
+        "devicesWithViewport": "This property is not set for desktops.",
+        "percentTraffic": "28.05%",
+        "percentTrafficPeriod": "From: 12/01/2020, To: 12/31/2020",
         "viewportPreset": "va-top-desktop-1",
         "width": 1280,
         "height": 960
@@ -126,9 +126,9 @@
       {
         "list": "VA Top Desktop Viewports",
         "rank": 2,
-        "devicesWithViewport": "Unknown",
-        "percentTraffic": 7.97,
-        "percentTrafficPeriod": "December, 2020",
+        "devicesWithViewport": "This property is not set for desktops.",
+        "percentTraffic": "8.23%",
+        "percentTrafficPeriod": "From: 12/01/2020, To: 12/31/2020",
         "viewportPreset": "va-top-desktop-2",
         "width": 1920,
         "height": 1080
@@ -136,9 +136,9 @@
       {
         "list": "VA Top Desktop Viewports",
         "rank": 3,
-        "devicesWithViewport": "Unknown",
-        "percentTraffic": 4.64,
-        "percentTrafficPeriod": "December, 2020",
+        "devicesWithViewport": "This property is not set for desktops.",
+        "percentTraffic": "4.83%",
+        "percentTrafficPeriod": "From: 12/01/2020, To: 12/31/2020",
         "viewportPreset": "va-top-desktop-3",
         "width": 1366,
         "height": 768
@@ -146,9 +146,9 @@
       {
         "list": "VA Top Desktop Viewports",
         "rank": 4,
-        "devicesWithViewport": "Unknown",
-        "percentTraffic": 3.66,
-        "percentTrafficPeriod": "December, 2020",
+        "devicesWithViewport": "This property is not set for desktops.",
+        "percentTraffic": "3.89%",
+        "percentTrafficPeriod": "From: 12/01/2020, To: 12/31/2020",
         "viewportPreset": "va-top-desktop-4",
         "width": 1440,
         "height": 900
@@ -156,9 +156,9 @@
       {
         "list": "VA Top Desktop Viewports",
         "rank": 5,
-        "devicesWithViewport": "Unknown",
-        "percentTraffic": 2.46,
-        "percentTrafficPeriod": "December, 2020",
+        "devicesWithViewport": "This property is not set for desktops.",
+        "percentTraffic": "2.59%",
+        "percentTrafficPeriod": "From: 12/01/2020, To: 12/31/2020",
         "viewportPreset": "va-top-desktop-5",
         "width": 1536,
         "height": 864

--- a/src/platform/testing/e2e/cypress/support/commands/viewportPreset.js
+++ b/src/platform/testing/e2e/cypress/support/commands/viewportPreset.js
@@ -1,22 +1,37 @@
 const presets = {
   // Top mobile presets by traffic percentage, descending
   'va-top-mobile-1': { width: 414, height: 896 },
-  'va-top-mobile-2': { width: 375, height: 667 },
-  'va-top-mobile-3': { width: 375, height: 812 },
+
+  'va-top-mobile-2': { width: 375, height: 812 },
+
+  'va-top-mobile-3': { width: 375, height: 667 },
+
   'va-top-mobile-4': { width: 414, height: 736 },
-  'va-top-mobile-5': { width: 320, height: 568 },
+
+  'va-top-mobile-5': { width: 360, height: 640 },
+
   // Top tablet presets by traffic percentage, descending
   'va-top-tablet-1': { width: 768, height: 1024 },
-  'va-top-tablet-2': { width: 1080, height: 1920 },
-  'va-top-tablet-3': { width: 720, height: 1280 },
+
+  'va-top-tablet-2': { width: 1920, height: 1080 },
+
+  'va-top-tablet-3': { width: 1280, height: 720 },
+
   'va-top-tablet-4': { width: 800, height: 1280 },
-  'va-top-tablet-5': { width: 601, height: 962 },
+
+  'va-top-tablet-5': { width: 1280, height: 800 },
+
   // Top desktop presets by traffic percentage, descending
   'va-top-desktop-1': { width: 1280, height: 960 },
+
   'va-top-desktop-2': { width: 1920, height: 1080 },
+
   'va-top-desktop-3': { width: 1366, height: 768 },
+
   'va-top-desktop-4': { width: 1440, height: 900 },
+
   'va-top-desktop-5': { width: 1536, height: 864 },
+
 };
 
 const isValidPreset = preset => presets[preset] !== undefined;


### PR DESCRIPTION
Updates `config/cypress.json` and `src/platform/testing/e2e/cypress/support/commands/viewportPreset.js` with Google Analytics viewport data from last month (12/2020).

These files are updated automatically via a Sidekiq job in `vets-api` that runs at noon on the 2nd day of each month to get the analytics data for the previous month. (Google Analytics updates every 24 hours.)